### PR TITLE
Fixes reverse proxy for API

### DIFF
--- a/nginx/bluecore.conf
+++ b/nginx/bluecore.conf
@@ -12,7 +12,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://bc_api:8100/?$args;
+        proxy_pass http://bc_api:8100/;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_protocol_addr;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
The `?$args` was preventing the reverse proxy for routes like `/api/works/` and `/api/instances/` to API service.